### PR TITLE
Add log.Printf compatible API

### DIFF
--- a/nanolog_test.go
+++ b/nanolog_test.go
@@ -835,6 +835,18 @@ func BenchmarkLogParallel(b *testing.B) {
 	})
 }
 
+func BenchmarkPrintfParallel(b *testing.B) {
+	w = bufio.NewWriter(ioutil.Discard)
+	args := []interface{}{int64(1), "string", uint32(2), uint32(3)}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Printf("foo thing bar thing %i64. Fubar %s foo. sadfasdf %u32 sdfasfasdfasdffds %u32.", args...)
+		}
+	})
+}
+
 func BenchmarkLogSequential(b *testing.B) {
 	w = bufio.NewWriter(ioutil.Discard)
 	h := AddLogger("foo thing bar thing %i64. Fubar %s foo. sadfasdf %u32 sdfasfasdfasdffds %u32.")
@@ -846,7 +858,26 @@ func BenchmarkLogSequential(b *testing.B) {
 	}
 }
 
-func BenchmarkCompareToStdlib(b *testing.B) {
+func BenchmarkPrintfSequential(b *testing.B) {
+	w = bufio.NewWriter(ioutil.Discard)
+	args := []interface{}{int64(1), "string", uint32(2), uint32(3)}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Printf("foo thing bar thing %i64. Fubar %s foo. sadfasdf %u32 sdfasfasdfasdffds %u32.", args...)
+	}
+}
+
+func BenchmarkComparePrintfAndLogAndStdlib(b *testing.B) {
+	b.Run("NanologPrintf", func(b *testing.B) {
+		w = bufio.NewWriter(ioutil.Discard)
+		args := []interface{}{int64(1), "string", uint32(2), uint32(3)}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			Printf("foo thing bar thing %i64. Fubar %s foo. sadfasdf %u32 sdfasfasdfasdffds %u32.", args...)
+		}
+	})
 	b.Run("Nanolog", func(b *testing.B) {
 		w = bufio.NewWriter(ioutil.Discard)
 		h := AddLogger("foo thing bar thing %i64. Fubar %s foo. sadfasdf %u32 sdfasfasdfasdffds %u32.")


### PR DESCRIPTION
This commit adds a log.Printf compatible API.

Why? Because it I can. And it also turns out that the performance penalty is small enough, see below:

```
benchstat bench
name                                          time/op
ComparePrintfAndLogAndStdlib/NanologPrintf-8  152ns  3%
ComparePrintfAndLogAndStdlib/Nanolog-8        111ns  1%
ComparePrintfAndLogAndStdlib/Stdlib-8         826ns  1%
```

Also the memory allocation is not changed:

```
BenchmarkComparePrintfAndLogAndStdlib/NanologPrintf-8           10000000               153 ns/op               0 B/op          0 allocs/op
BenchmarkComparePrintfAndLogAndStdlib/Nanolog-8                 20000000               110 ns/op               0 B/op          0 allocs/op
BenchmarkComparePrintfAndLogAndStdlib/Stdlib-8                   2000000               849 ns/op              80 B/op          1 allocs/op
```